### PR TITLE
makefile: Pipe an tee, anstatt Umleitung

### DIFF
--- a/makefile
+++ b/makefile
@@ -19,9 +19,9 @@ outputdir:
 
 # Generate PDF output from LaTeX input files.
 report:
-	pdflatex -interaction=errorstopmode $(DOCUMENT_NAME) > error.txt
+	pdflatex -interaction=errorstopmode $(DOCUMENT_NAME) | tee error.txt
 	makeglossaries -q dokumentation.glo
 	makeglossaries -q dokumentation.acn
-	pdflatex -interaction=errorstopmode $(DOCUMENT_NAME) > error.txt
+	pdflatex -interaction=errorstopmode $(DOCUMENT_NAME) | tee error.txt
 	cp $(DOCUMENT_NAME).pdf $(OUTPUT_DIR)
 #	cp $(DOCUMENT_NAME).pdf $(ABGABE_DIR)


### PR DESCRIPTION
Bei Compilierungsfehlern stoppt pdflatex und wartet auf Nutzeraktionen. 
Der Nutzer kann jedoch nicht adequat interagieren, da stdout an error.txt weitergeleitet wird. Alternative: tee
