### PR TITLE
Mehr LaTeX Temporaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 *.bbl
 *.blg
 .project
+*.fdb_latexmk
+*.fls


### PR DESCRIPTION
ein kleiner commit, der noch zwei weitere File Typen auf die .gitignore Liste setzt.
