### PR TITLE
Unnummerierte Kapitel (bisher \chapter*)  korrekt in Kopfzeile anzeigen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .project
 output/
 dokumentation.pdf
+*.pdf
 *.swp
 *.backup
+*.bak
 *.orig

--- a/ads/acronyms.tex
+++ b/ads/acronyms.tex
@@ -1,6 +1,6 @@
 %!TEX root = ../dokumentation.tex
 
-\chapter*{\langabkverz}
+\addchap{\langabkverz}
 %nur verwendete Akronyme werden letztlich im Abkürzungsverzeichnis des Dokuments angezeigt
 %Verwendung: 
 %		\ac{Abk.}   --> fügt die Abkürzung ein, beim ersten Aufruf wird zusätzlich automatisch die ausgeschriebene Version davor eingefügt bzw. in einer Fußnote (hierfür muss in header.tex \usepackage[printonlyused,footnote]{acronym} stehen) dargestellt

--- a/ads/appendix.tex
+++ b/ads/appendix.tex
@@ -10,7 +10,7 @@
 \end{enumerate}
 }
 \pagebreak
-\includepdf[pages=-,scale=.9,pagecommand={}]{Aufgabenstellung.pdf} % PDF um 10% verkleinert einbinden --> Kopf- und Fußzeile  werden so korrekt dargestellt. Die Option `pages' ermöglicht es, eine bestimmte Sequenz von Seiten (z.B. 2-10 oder `-' für alle Seiten) auszuwählen.
+%\includepdf[pages=-,scale=.9,pagecommand={}]{Aufgabenstellung.pdf} % PDF um 10% verkleinert einbinden --> Kopf- und Fußzeile  werden so korrekt dargestellt. Die Option `pages' ermöglicht es, eine bestimmte Sequenz von Seiten (z.B. 2-10 oder `-' für alle Seiten) auszuwählen.
 \pagebreak
 \section*{B. List of CD Contents}
 \begin{tabbing}
@@ -21,24 +21,24 @@
 	| \> | \> \> \textit{The PDFs linked to bibliography items therein} \\
 	| \> | \> \> \textit{are in the sub-directory `CitaviFiles'}\\
 	| \> | \>  -- bibliography.bib  \> $\Rightarrow$ \textit{Exported Bibliography file with all sources}\\
-	| \> | \>  --	Studienarbeit.ctv4  $\Rightarrow$ \textit{Citavi Project file}\\
+	| \> | \>  --	Studienarbeit.ctv4  \>  $\Rightarrow$ \textit{Citavi Project file}\\
 	| \> | \>  $\vdash$ \textbf{CitaviCovers/} \>  $\Rightarrow$ \textit{Images of bibliography cover pages}\\
-	| \> | \>  $\llcorner$ \textbf{CitaviFiles/} \> $\Rightarrow$ \textit{Cited and most other found PDF resources}\\
+	| \> | \>  $\vdash$ \textbf{CitaviFiles/} \> $\Rightarrow$ \textit{Cited and most other found PDF resources}\\ %\llcorner
 	| \> $\vdash$ \textbf{eBooks/} \\
 	| \> $\vdash$ \textbf{JournalArticles/} \\
 	| \> $\vdash$ \textbf{Standards/}\\
-	| \> $\llcorner$ \textbf{Websites/} \\
+	| \> $\vdash$ \textbf{Websites/} \\ %\llcorner
 	|\\
 	$\vdash$ \textbf{Presentation/} \\
 	| \>  --presentation.pptx\\
 	| \>  --presentation.pdf\\
 	|\\
-	$\llcorner$ \textbf{Report/} \\
+	$\vdash$ \textbf{Report/} \\ %\llcorner
 	\>  -- Aufgabenstellung.pdf\\
 	\>  -- Studienarbeit2.pdf\\
-	\>  $\llcorner$ \textbf{Latex-Files/}   $\Rightarrow$ \textit{editable \LaTeX~files and other included files for this report}\\
+	\>  $\vdash$ \textbf{Latex-Files/}   $\Rightarrow$ \textit{editable \LaTeX~files and other included files for this report}\\ %\llcorner
 	\> \>  $\vdash$  \textbf{ads/}   	\> $\Rightarrow$ \textit{Front- and Backmatter}\\
 	\> \>  $\vdash$  \textbf{content/}  \> $\Rightarrow$ \textit{Main part}\\
 	\> \>  $\vdash$  \textbf{images/}   \> $\Rightarrow$ \textit{All used images}\\
-	\> \>  $\llcorner$  \textbf{lang/}  \> $\Rightarrow$ \textit{Language files for \LaTeX~template}\\
+	\> \>  $\vdash$  \textbf{lang/}  \> $\Rightarrow$ \textit{Language files for \LaTeX~template}\\ %\llcorner
 \end{tabbing}

--- a/ads/appendix.tex
+++ b/ads/appendix.tex
@@ -1,0 +1,44 @@
+% !TeX root = ../dokumentation.tex
+
+\addchap{\langanhang}
+
+{\Large
+\begin{enumerate}
+	\item[A.] Assignment
+	\item[B.] List of CD Contents
+	\item[C.] CD 
+\end{enumerate}
+}
+\pagebreak
+\includepdf[pages=-,scale=.9,pagecommand={}]{Aufgabenstellung.pdf} % PDF um 10% verkleinert einbinden --> Kopf- und Fußzeile  werden so korrekt dargestellt. Die Option `pages' ermöglicht es, eine bestimmte Sequenz von Seiten (z.B. 2-10 oder `-' für alle Seiten) auszuwählen.
+\pagebreak
+\section*{B. List of CD Contents}
+\begin{tabbing}
+	mm \= mm \= mmmmmmmmmmmmmmmm \= \kill
+	$\vdash$ \textbf{Literature/} \\ 
+	| \> $\vdash$ \textbf{Citavi-Project(incl pdfs)/} \> \> $\Rightarrow$ \textit{Citavi (bibliography software) project with}\\
+	| \> | \> \> \textit{almost all found sources relating to this report.} \\
+	| \> | \> \> \textit{The PDFs linked to bibliography items therein} \\
+	| \> | \> \> \textit{are in the sub-directory `CitaviFiles'}\\
+	| \> | \>  -- bibliography.bib  \> $\Rightarrow$ \textit{Exported Bibliography file with all sources}\\
+	| \> | \>  --	Studienarbeit.ctv4  $\Rightarrow$ \textit{Citavi Project file}\\
+	| \> | \>  $\vdash$ \textbf{CitaviCovers/} \>  $\Rightarrow$ \textit{Images of bibliography cover pages}\\
+	| \> | \>  $\llcorner$ \textbf{CitaviFiles/} \> $\Rightarrow$ \textit{Cited and most other found PDF resources}\\
+	| \> $\vdash$ \textbf{eBooks/} \\
+	| \> $\vdash$ \textbf{JournalArticles/} \\
+	| \> $\vdash$ \textbf{Standards/}\\
+	| \> $\llcorner$ \textbf{Websites/} \\
+	|\\
+	$\vdash$ \textbf{Presentation/} \\
+	| \>  --presentation.pptx\\
+	| \>  --presentation.pdf\\
+	|\\
+	$\llcorner$ \textbf{Report/} \\
+	\>  -- Aufgabenstellung.pdf\\
+	\>  -- Studienarbeit2.pdf\\
+	\>  $\llcorner$ \textbf{Latex-Files/}   $\Rightarrow$ \textit{editable \LaTeX~files and other included files for this report}\\
+	\> \>  $\vdash$  \textbf{ads/}   	\> $\Rightarrow$ \textit{Front- and Backmatter}\\
+	\> \>  $\vdash$  \textbf{content/}  \> $\Rightarrow$ \textit{Main part}\\
+	\> \>  $\vdash$  \textbf{images/}   \> $\Rightarrow$ \textit{All used images}\\
+	\> \>  $\llcorner$  \textbf{lang/}  \> $\Rightarrow$ \textit{Language files for \LaTeX~template}\\
+\end{tabbing}

--- a/ads/sperrvermerk.tex
+++ b/ads/sperrvermerk.tex
@@ -35,4 +35,5 @@ Jede anderweitige Einsichtnahme und Veröffentlichung – auch von Teilen der Ar
 \abgabeort, \datumAbgabe
 \vspace{4em}
 
+\rule{6cm}{0.4pt}\\
 \autor

--- a/dokumentation.tex
+++ b/dokumentation.tex
@@ -53,8 +53,6 @@
 
 	% Abkürzungsverzeichnis
 	\cleardoublepage
-	\phantomsection \label{listofacs}
-	\addcontentsline{toc}{chapter}{\langabkverz}
 	\input{ads/acronyms}
 
 	% Abbildungsverzeichnis
@@ -85,9 +83,7 @@
 			}
 	}
 
-	% Anhang
 	\clearpage
-	%\pagenumbering{roman}
 
 	% Literaturverzeichnis
 	\cleardoublepage
@@ -95,4 +91,10 @@
 
 	% Glossar
 	\printglossary[style=altlist,title=\langglossar]
+	
+	% sonstiger Anhang
+	\clearpage
+	\appendix
+	\input{ads/appendix}
+	
 \end{document}

--- a/einstellungen.tex
+++ b/einstellungen.tex
@@ -31,7 +31,7 @@
 \setzeabschluss{Bachelor of Engineering}
 \setzestudiengang{Vorderasiatische Archäologie}
 \setzedhbw{Karlsruhe}
-\setzebetreuer{Dipl.-Ing. (FH) Peter Pan}
+\setzebetreuer{Dipl.-Ing.~(FH) Peter Pan}
 \setzegutachter{Dr.\ Silvana Koch-Mehrin}
 \setzezeitraum{12 Wochen}
 \setzearbeit{Bachelorarbeit}
@@ -118,3 +118,5 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Eigenes %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Hier können Ergänzungen zur Präambel vorgenommen werden (eigene Pakete, Einstellungen)
 
+
+\usepackage{pdfpages}

--- a/lang/de.tex
+++ b/lang/de.tex
@@ -13,6 +13,7 @@
 \setzelangerklaerung{Erklärung}
 \setzelangabkverz{Abkürzungsverzeichnis}
 \setzelangglossar{Glossar}
+\setzelanganhang{Anhang}
 \setzelangabstract{Abstract}
 \setzelanglistingname{Listing}
 \setzelanglistlistingname{Listings}

--- a/lang/en.tex
+++ b/lang/en.tex
@@ -1,7 +1,7 @@
 \setzelangdeckblattabschlusshinleitung{for the}
-\setzelangartikelstudiengang{at}
-\setzelangstudiengang{the course}
-\setzelanganderdh{at the Cooperative State University}
+\setzelangartikelstudiengang{from}
+\setzelangstudiengang{the Course of Studies}
+\setzelanganderdh{at the Cooperative State University Baden-Württemberg}
 \setzelangvon{by}
 \setzelangdbbearbeitungszeit{Time of Project}
 \setzelangdbmatriknr{Student ID}
@@ -9,11 +9,12 @@
 \setzelangdbfirma{Company}
 \setzelangdbbetreuer{Supervisor in the Company}
 \setzelangdbgutachter{Reviewer}
-\setzelangsperrvermerk{Restriction Notice}
+\setzelangsperrvermerk{Confidentiality Statement} %Restriction Notice}
 \setzelangerklaerung{Author's declaration}
 \setzelangglossar{Glossary}
 \setzelangabkverz{Acronyms}
 \setzelangabstract{Abstract}
+\setzelanganhang{Appendix}
 \setzelanglistingname{Listing}
 \setzelanglistlistingname{Listings}
 \setzelanglistingautorefname{Listing}

--- a/lang/strings.tex
+++ b/lang/strings.tex
@@ -3,6 +3,7 @@
 }
 
 \langstr{abkverz}
+\langstr{anhang}
 \langstr{glossar}
 \langstr{deckblattabschlusshinleitung}
 \langstr{artikelstudiengang}


### PR DESCRIPTION
KOMA-Script \addchap generiert im Gegensatz zu \chapter* automatisch Einträge in Kopfzeile und Inhaltsverzeichnis

 * ansonsten noch ein Anhangs-Kapitel (Appendix) hinzugefügt
 * geringfügige Korrekturen in en.tex, (schon bei meinem Pull request #28 vorhanden)
 * Unterschriftenlinie beim Sperrvermerk (schon bei meinem Pull request #29 vorhanden)

diesmal auf Grundlage der aktuellen Basis --> auto merge möglich