### PR TITLE
Die Art der Arbeit nach ihrem Geschlecht unterschieden

### DIFF
--- a/ads/einstellungen_liste.tex
+++ b/ads/einstellungen_liste.tex
@@ -20,3 +20,5 @@
 \einstellung{spaltenabstand}
 \einstellung{zeilenabstand}
 \einstellung{zitierstil}
+\einstellung{artikelArbeit}
+\einstellung{meineArbeit}

--- a/ads/erklaerung.tex
+++ b/ads/erklaerung.tex
@@ -9,11 +9,11 @@
 \iflang{de}{%
 Ich erkläre hiermit ehrenwörtlich: \\
 \begin{enumerate}
-\item dass ich meine {\arbeit} mit dem Thema
+\item dass ich {\meineArbeit} {\arbeit} mit dem Thema
 {\itshape \titel } ohne fremde Hilfe angefertigt habe;
 \item dass ich die Übernahme wörtlicher Zitate aus der Literatur sowie die Verwendung der Gedanken
 anderer Autoren an den entsprechenden Stellen innerhalb der Arbeit gekennzeichnet habe;
-\item dass ich meine {\arbeit} bei keiner anderen Prüfung vorgelegt habe;
+\item dass ich {\meineArbeit} {\arbeit} bei keiner anderen Prüfung vorgelegt habe;
 \item dass die eingereichte elektronische Fassung exakt mit der eingereichten schriftlichen Fassung
 übereinstimmt.
 \end{enumerate}

--- a/ads/sperrvermerk.tex
+++ b/ads/sperrvermerk.tex
@@ -7,7 +7,7 @@
 \vspace*{2em}
 
 \iflang{de}{%
-  Die vorliegende {\arbeit} mit dem Titel {\itshape{} \titel{}\/} enthält unternehmensinterne bzw. vertrauliche Informationen der {\firma}, ist deshalb mit einem Sperrvermerk versehen und wird ausschließlich zu Prüfungszwecken am Studiengang {\studiengang} der Dualen Hochschule Baden-Württemberg {\dhbw} vorgelegt. Sie ist ausschließlich zur Einsicht durch den zugeteilten Gutachter, die Leitung des Studiengangs und ggf. den Prüfungsausschuss des Studiengangs bestimmt.  Es ist untersagt,
+  {\artikelArbeit} vorliegende {\arbeit} mit dem Titel {\itshape{} \titel{}\/} enthält unternehmensinterne bzw. vertrauliche Informationen der {\firma}, ist deshalb mit einem Sperrvermerk versehen und wird ausschließlich zu Prüfungszwecken am Studiengang {\studiengang} der Dualen Hochschule Baden-Württemberg {\dhbw} vorgelegt. Sie ist ausschließlich zur Einsicht durch den zugeteilten Gutachter, die Leitung des Studiengangs und ggf. den Prüfungsausschuss des Studiengangs bestimmt.  Es ist untersagt,
   \begin{itemize}
   \item den Inhalt dieser Arbeit (einschließlich Daten, Abbildungen, Tabellen, Zeichnungen usw.) als Ganzes oder auszugsweise weiterzugeben,
   \item Kopien oder Abschriften dieser Arbeit (einschließlich Daten, Abbildungen, Tabellen, Zeichnungen usw.) als Ganzes oder in Auszügen anzufertigen,

--- a/einstellungen.tex
+++ b/einstellungen.tex
@@ -36,6 +36,9 @@
 \setzezeitraum{12 Wochen}
 \setzearbeit{Bachelorarbeit}
 \setzeautor{Vorname Nachname}
+%nur bei Sprachauswahl de verwendet
+\setzeartikelArbeit{Die} %bestimmt den Artikel der Arbeit, Bsp. Die Bachelorarbeit, Der Projektbericht
+\setzemeineArbeit{meine} % ...,dass ich meine/n Arbeit ...  Bsp. meine Bachelorarbeit, meinen Projektbericht
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%% Literaturverzeichnis %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Bisher war in dem Sperrvermerk nur: "Die vorliegende (Art der Arbeit) mit ...." Der Projektbericht ist aber männlich und müsste deshalb "Der vorliegende Projektbericht mit..."
In der Erklärung hieß es "..,dass ich meine (Art der Arbeit)..." das Wort meine ist aber auch hier nicht in der richtigen Form beim Projektbericht und müsste heißen: "...,dass ich meinen Projektbericht.."

Diese beiden Einstellungen kann man nun in der einstellungen.tex ändern.